### PR TITLE
chore(ci): remove pnpm turbo db generate on ci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,6 @@ jobs:
       - name: Install deps (with cache)
         run: pnpm install
 
-      # Normally, this would be done as part of the turbo pipeline - however since the Expo app doesn't depend on `@acme/db` it doesn't care.
-      # TODO: Free for all to find a better solution here.
-      # - name: Generate Prisma Client
-      #   run: pnpm turbo db:generate
-
       - name: Build, lint and type-check
         run: pnpm turbo build lint type-check
         env:


### PR DESCRIPTION
Remove the name and run comment of Generate prisma client with `pnpm turbo db:generate`.