### PR TITLE
feat(ui): display SiteFQAsItem on one column instead of two

### DIFF
--- a/apps/www/src/components/SiteFAQs/SiteFAQs.tsx
+++ b/apps/www/src/components/SiteFAQs/SiteFAQs.tsx
@@ -33,11 +33,8 @@ const SiteFAQs = () => {
         </p>
       </div>
 
-      <div className='mx-auto grid w-full max-w-4xl grid-cols-2 gap-6'>
-        <SiteFAQsItems faqs={faqs.slice(0, Math.ceil(faqs.length / 2))} />
-        <SiteFAQsItems
-          faqs={faqs.slice(Math.ceil(faqs.length / 2), faqs.length)}
-        />
+      <div className='mx-auto grid w-full max-w-4xl gap-6 px-10'>
+        <SiteFAQsItems faqs={faqs} />
       </div>
     </div>
   );

--- a/apps/www/src/components/SiteFAQs/SiteFAQsItem.tsx
+++ b/apps/www/src/components/SiteFAQs/SiteFAQsItem.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const SiteFAQsItem = ({ title, description }: Props) => {
   return (
-    <AccordionItem value={title}>
+    <AccordionItem className='py-2' value={title}>
       <AccordionTrigger>{title}</AccordionTrigger>
       <AccordionContent>{description}</AccordionContent>
     </AccordionItem>


### PR DESCRIPTION
Display SiteFQAsItem component on 1 column instead of 2, and add padding on "Y" axis for AccordionItem component